### PR TITLE
Fix results when searching by movie

### DIFF
--- a/lib/rottentomatoes/rottentomatoes.rb
+++ b/lib/rottentomatoes/rottentomatoes.rb
@@ -66,7 +66,7 @@ module RottenTomatoes
 
       results.map!{|m| RottenMovie.new(m, options[:expand_results])}
 
-      if (results.length == 1)
+      if (options[:id] || options[:imdb] || options[:limit] == 1)
         return results[0]
       else
         return results

--- a/spec/rotten_movie_spec.rb
+++ b/spec/rotten_movie_spec.rb
@@ -28,6 +28,12 @@ describe RottenMovie do
       movies.each do |movie|
         movie.should be_a_kind_of OpenStruct
       end
+
+      movies = RottenMovie.find(:title => "Eternal Sunshine")
+      movies.should be_a_kind_of Array
+      movies.each do |movie|
+        movie.should be_a_kind_of OpenStruct
+      end
     end
 
     it "should return a single movie when limit=1 and searching by title" do


### PR DESCRIPTION
When searching for movies by :title, we should return an array unless the user
specifies a :limit of 1. The previous spec just happened to test a query that
had more than one result ("Fight Club").

Test Plan:

```
rspec spec
```
#### NOTE:

imho, I think the API should always return an array when searching by `:title`. Seems weird that the result type is different when a special `:limit` is set.
