### PR TITLE
Add page options for API call

### DIFF
--- a/lib/rottentomatoes/rottentomatoes.rb
+++ b/lib/rottentomatoes/rottentomatoes.rb
@@ -42,6 +42,7 @@ module RottenTomatoes
       url += "?apikey=" + @@api_key 
       url += "&q=" + CGI::escape(options[:title].to_s) if (method == "movies" && !options[:title].nil? && options[:id].nil?)
       url += "&type=imdb&id=%07d" % options[:imdb].to_i if (method == "movie_alias")
+      url += "&page=%d" % options[:page].to_i if options[:page]
 
       response = get_url(url)
       return nil if(response.code.to_i != 200)


### PR DESCRIPTION
RottenTomates provides paged results and I needed to navigate through those pages easily.

``` RUBY
RottenList.find(type: 'new_releases', page: 2)
```
