### PR TITLE
Method returns false but is later referenced as an object

### DIFF
--- a/lib/rottentomatoes/rottentomatoes.rb
+++ b/lib/rottentomatoes/rottentomatoes.rb
@@ -45,7 +45,7 @@ module RottenTomatoes
       url += "&type=imdb&id=%07d" % options[:imdb].to_i if (method == "movie_alias")
 
       response = get_url(url)
-      return nil if(response.code.to_i != 200)
+      return nil if(response == false || response.code.to_i != 200)
       body = JSON(response.body)
 
       if (body["total"] == 0 && body["title"].nil?)


### PR DESCRIPTION
Someone already created an issue for this but we experienced the same issue at work today so I created a PR. 

NoMethodError: undefined method `code' for false:FalseClass
/var/www/istreamguide/shared/bundle/ruby/2.1.0/gems/rottentomatoes-    1.1.0/lib/rottentomatoes/rottentomatoes.rb:47:in`api_call'
/var/www/istreamguide/shared/bundle/ruby/2.1.0/gems/rottentomatoes-  1.1.0/lib/rottentomatoes/rotten_movie.rb:9:in `find'
/var/www/istreamguide/releases/20150512234310/app/models/movie.rb:99:in`rotten_api_call'
/var/www/istreamguide/releases/20150512234310/lib/tasks/data.rake:173:in `block (3 levels) in <top (required)>'
/var/www/istreamguide/shared/bundle/ruby/2.1.0/gems/activerecord-4.2.1/lib/active_record/relation/batches.rb:51:in`block (2 levels) in find_each'
/var/www/istreamguide/shared/bundle/ruby/2.1.0/gems/activerecord-4.2.1/lib/active_record/relation/batches.rb:51:in `each'
/var/www/istreamguide/shared/bundle/ruby/2.1.0/gems/activerecord-4.2.1/lib/active_record/relation/batches.rb:51:in`block in find_each'
/var/www/istreamguide/shared/bundle/ruby/2.1.0/gems/activerecord-4.2.1/lib/active_record/relation/batches.rb:124:in `find_in_batches'
/var/www/istreamguide/shared/bundle/ruby/2.1.0/gems/activerecord-4.2.1/lib/active_record/relation/batches.rb:50:in`find_each'
/var/www/istreamguide/releases/20150512234310/lib/tasks/data.rake:172:in `block (2 levels) in <top (required)>'
